### PR TITLE
Don't try to run command in obsolete container (locally built).

### DIFF
--- a/rego
+++ b/rego
@@ -312,7 +312,14 @@ class Image:
             generated_options.extend(["--tag", tag])
 
         run = ["docker", "build"] + generated_options + options_from_config
-        _subprocess_run(" ".join(run), stdout=subprocess.DEVNULL)
+        res = _subprocess_run(" ".join(run), stdout=subprocess.DEVNULL)
+        if res.returncode != 0:
+            _logger.error(
+                "error at attempt to build docker image. "
+                "Can't proceed further. Please check the output"
+            )
+            sys.exit(res.returncode)
+
         return tag
 
     def run(self, docker_run_options: List[str], command_to_run: str):


### PR DESCRIPTION
Before running a command, which should be run in a docker container, defined by local Dockerfile, rego tries to (re)build those container. Currently, rego ignores errors, which happen at build step. For the very first run it will lead to error anyway, because rego will not be able to run container, which is not built yet. But if container was already build in the past, later some error(s) were introduced to Dockerfile and build fails, rego will use old version of the container, what is incorrect.
It should clearly state that build of container failed.