### PR TITLE
Docker compose: use '--service-ports'

### DIFF
--- a/runo
+++ b/runo
@@ -29,7 +29,7 @@ from typing import (
     Union,
 )
 
-__version__ = "25.10.10-e879d7bf"
+__version__ = "25.10.10-99069d04"
 
 # runo uses .toml format of config files, but parsers for this format
 # might be not available in old python versions (only in 3.11 tomllib
@@ -364,7 +364,7 @@ class Composition:
             [self.compose_base]
             + self._generated_options
             + self._compose_options_from_config
-            + ["run --build"]
+            + ["run --build --service-ports"]
             + docker_run_options
             + [self._cfg["docker_compose_service"]]
             + [command_to_run]

--- a/tests/unit/test_runo.py
+++ b/tests/unit/test_runo.py
@@ -1233,7 +1233,7 @@ class TestDockerComposeServiceCommands(BaseCommandsTest):
                 "docker",
                 "compose",
                 *expected_docker_compose_options,
-                "run --build",
+                "run --build --service-ports",
             ]
             + _expected_docker_run_options(docker_run_options_str)
             + [container_config["docker_compose_service"]]


### PR DESCRIPTION
"docker compose run" does not create any of the ports specified in the service configuration by default. This is the problem for us, because user will need to specify "-p 8000:8000" or similar in docker run options, what is inconvinient.